### PR TITLE
Adding in New projects for 2024

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 
 # Temporarily ignore this
 /src/media
-earth_temp.md
 gp_website.md
 job_search_bot.md
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 
 # Temporarily ignore this
 /src/media
+earth_temp.md
+gp_website.md
+job_search_bot.md
 
 # dependencies
 /node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,6 @@
 
 # Temporarily ignore this
 /src/media
-gp_website.md
-job_search_bot.md
 
 # dependencies
 /node_modules

--- a/src/components/HomeView.js
+++ b/src/components/HomeView.js
@@ -32,6 +32,9 @@ const HomeView = () => {
                 <h2>Software Development Experience</h2>
                 <div className='row'>
                     <div className='border col col-md-5 col-11 my-2 mx-xl-5 mx-md-4 mx-3'>
+                        <RenderMarkup fileName={`${software_portfolio_path}earth_temp.md`}/>
+                    </div>
+                    <div className='border col col-md-5 col-11 my-2 mx-xl-5 mx-md-4 mx-3'>
                         <RenderMarkup fileName={`${software_portfolio_path}portfolio_specs.md`}/>
                     </div>
                     <div className='border col col-md-5 col-11 my-2 mx-xl-5 mx-md-4 mx-3'>

--- a/src/markdown/coding_portfolio/earth_temp.md
+++ b/src/markdown/coding_portfolio/earth_temp.md
@@ -1,0 +1,16 @@
+## Earth Temperature Graph
+***Role:*** Data Analyst
+
+***TechStack:*** [Python](https://www.python.org/), [Numpy](https://numpy.org/), [Matplotlib](https://matplotlib.org/), and [Pandas](https://pandas.pydata.org/)
+
+[<img src="https://upload.wikimedia.org/wikipedia/commons/c/c3/Python-logo-notext.svg" alt="Python logo" height="50">](https://www.python.org/) [<img src="https://upload.wikimedia.org/wikipedia/commons/3/31/NumPy_logo_2020.svg" alt="NumPy Logo" height="50">](https://numpy.org/) [<img src="https://upload.wikimedia.org/wikipedia/commons/8/84/Matplotlib_icon.svg" alt="Matplotlib Logo" height="50">](https://matplotlib.org/) [<img src="https://upload.wikimedia.org/wikipedia/commons/2/22/Pandas_mark.svg" alt="Pandas Logo" height="50">](https://pandas.pydata.org/)
+
+***Links:*** [GITHUB](https://github.com/robert-godlewski/earth_temp)
+
+**Started Date:** June 2024
+
+***Description:*** Graph representing the global warming on earth.
+* Utilized [Pandas](https://pandas.pydata.org/) to mine and format over 1000 points of raw data needed compile temperature information.
+* Designed the graph using [Matplotlib](https://matplotlib.org/) to plot over 1000 data points to present.
+* Applied [Numpy](https://numpy.org/) arrays to automatically determine the size of both x and y axis to be graphed.
+* Utilized [Numpy](https://numpy.org/) arrays to quickly calculate and predict how warm the earth got over 50 years.

--- a/src/markdown/coding_portfolio/earth_temp.md
+++ b/src/markdown/coding_portfolio/earth_temp.md
@@ -11,6 +11,6 @@
 
 ***Description:*** Graph representing the global warming on earth.
 * Utilized [Pandas](https://pandas.pydata.org/) to mine and format over 1000 points of raw data needed compile temperature information.
-* Designed the graph using [Matplotlib](https://matplotlib.org/) to plot over 1000 data points to present.
-* Applied [Numpy](https://numpy.org/) arrays to automatically determine the size of both x and y axis to be graphed.
-* Utilized [Numpy](https://numpy.org/) arrays to quickly calculate and predict how warm the earth got over 50 years.
+* Determine x and y axis by using [NumPy](https://numpy.org/) arrays to automatically give the range of values to be graphed.
+* Designed the graph using [Matplotlib](https://matplotlib.org/) to plot over 1000 data points to graph.
+* Utilized [NumPy](https://numpy.org/) arrays to quickly calculate and predict how warm the earth got over 50 years.

--- a/src/markdown/coding_portfolio/earth_temp.md
+++ b/src/markdown/coding_portfolio/earth_temp.md
@@ -1,11 +1,11 @@
 ## Earth Temperature Graph
 ***Role:*** Data Analyst
 
-***TechStack:*** [Python](https://www.python.org/), [Numpy](https://numpy.org/), [Matplotlib](https://matplotlib.org/), and [Pandas](https://pandas.pydata.org/)
+***Tech Stack:*** [Python](https://www.python.org/), [Numpy](https://numpy.org/), [Matplotlib](https://matplotlib.org/), and [Pandas](https://pandas.pydata.org/)
 
 [<img src="https://upload.wikimedia.org/wikipedia/commons/c/c3/Python-logo-notext.svg" alt="Python logo" height="50">](https://www.python.org/) [<img src="https://upload.wikimedia.org/wikipedia/commons/3/31/NumPy_logo_2020.svg" alt="NumPy Logo" height="50">](https://numpy.org/) [<img src="https://upload.wikimedia.org/wikipedia/commons/8/84/Matplotlib_icon.svg" alt="Matplotlib Logo" height="50">](https://matplotlib.org/) [<img src="https://upload.wikimedia.org/wikipedia/commons/2/22/Pandas_mark.svg" alt="Pandas Logo" height="50">](https://pandas.pydata.org/)
 
-***Links:*** [GITHUB](https://github.com/robert-godlewski/earth_temp)
+***Link:*** [GITHUB](https://github.com/robert-godlewski/earth_temp)
 
 **Started Date:** June 2024
 

--- a/src/markdown/coding_portfolio/gp_website.md
+++ b/src/markdown/coding_portfolio/gp_website.md
@@ -1,15 +1,15 @@
 ## Ghost Pants Website
 ***Role:*** Full Stack Developer
 
-***Tech Stack:*** [Python](https://www.python.org/), [JavaScript](https://ecma-international.org/publications-and-standards/standards/ecma-262/), [Django](https://www.djangoproject.com/), and [React.js](https://react.dev/)
+***Tech Stack:*** [Python](https://www.python.org/), [JavaScript](https://ecma-international.org/publications-and-standards/standards/ecma-262/), [Django](https://www.djangoproject.com/), [React.js](https://react.dev/), and [PostgreSQL](https://www.postgresql.org/)
 
-[<img src="https://upload.wikimedia.org/wikipedia/commons/c/c3/Python-logo-notext.svg" alt="Python logo" height="50">](https://www.python.org/) [<img src="https://upload.wikimedia.org/wikipedia/commons/6/6a/JavaScript-logo.png" alt="JavaScript logo" height="50">](https://ecma-international.org/publications-and-standards/standards/ecma-262/) [<img src="https://static.djangoproject.com/img/logos/django-logo-negative.png" alt="Django logo" height="50">](https://www.djangoproject.com/) [<img src="https://upload.wikimedia.org/wikipedia/commons/a/a7/React-icon.svg" alt="React.js Logo" height="50">](https://react.dev/) [<img src="https://upload.wikimedia.org/wikipedia/commons/3/38/HTML5_Badge.svg" alt="HTML5 logo" height="50">](https://html.spec.whatwg.org/) [<img src="https://upload.wikimedia.org/wikipedia/commons/6/62/CSS3_logo.svg" alt="CSS3 logo" height="50">](https://www.w3.org/TR/CSS/)
+[<img src="https://upload.wikimedia.org/wikipedia/commons/c/c3/Python-logo-notext.svg" alt="Python logo" height="50">](https://www.python.org/) [<img src="https://upload.wikimedia.org/wikipedia/commons/6/6a/JavaScript-logo.png" alt="JavaScript logo" height="50">](https://ecma-international.org/publications-and-standards/standards/ecma-262/) [<img src="https://static.djangoproject.com/img/logos/django-logo-negative.png" alt="Django logo" height="50">](https://www.djangoproject.com/) [<img src="https://upload.wikimedia.org/wikipedia/commons/a/a7/React-icon.svg" alt="React.js Logo" height="50">](https://react.dev/) [<img src="https://upload.wikimedia.org/wikipedia/commons/3/38/HTML5_Badge.svg" alt="HTML5 logo" height="50">](https://html.spec.whatwg.org/) [<img src="https://upload.wikimedia.org/wikipedia/commons/6/62/CSS3_logo.svg" alt="CSS3 logo" height="50">](https://www.w3.org/TR/CSS/) [<img src="https://upload.wikimedia.org/wikipedia/commons/2/29/Postgresql_elephant.svg" alt="PostgreSQL Logo" height="50">](https://www.postgresql.org/)
 
-***Link:*** [GITHUB](https://github.com/robert-godlewski/ghost_pants_website)
+***Links:*** [LIVE SITE](https://0fd6eadc-3d96-4eab-91ea-961d9c91cff9.e1-us-cdp-2.choreoapps.dev/), [GITHUB](https://github.com/robert-godlewski/ghost_pants_website)
 
 **Started Date:** June 2024
 
 ***Description:*** Blog Website talking about video games.
 * Serialized [Django](https://www.djangoproject.com/) ORM as an API inorder for [React.js](https://react.dev/) to render 5 routes to be viewed for the UI.
 * Utilized JWT to authorize users for fast access to sensitive data.
-* Deployed full stack application using Choreo for people to engage with the live site.
+* Deployed full stack application using 3 components on [Choreo](https://choreo.dev/) for people to engage with the live site.

--- a/src/markdown/coding_portfolio/gp_website.md
+++ b/src/markdown/coding_portfolio/gp_website.md
@@ -1,0 +1,17 @@
+## Ghost Pants Website
+***Role:*** Full Stack Developer
+
+***Tech Stack:*** [Python](https://www.python.org/), [JavaScript](https://ecma-international.org/publications-and-standards/standards/ecma-262/), [Django](https://www.djangoproject.com/), and [React.js](https://react.dev/)
+
+[<img src="https://upload.wikimedia.org/wikipedia/commons/c/c3/Python-logo-notext.svg" alt="Python logo" height="50">](https://www.python.org/) [<img src="https://upload.wikimedia.org/wikipedia/commons/6/6a/JavaScript-logo.png" alt="JavaScript logo" height="50">](https://ecma-international.org/publications-and-standards/standards/ecma-262/) [<img src="https://static.djangoproject.com/img/logos/django-logo-negative.png" alt="Django logo" height="50">](https://www.djangoproject.com/) [<img src="https://upload.wikimedia.org/wikipedia/commons/a/a7/React-icon.svg" alt="React.js Logo" height="50">](https://react.dev/) [<img src="https://upload.wikimedia.org/wikipedia/commons/3/38/HTML5_Badge.svg" alt="HTML5 logo" height="50">](https://html.spec.whatwg.org/) [<img src="https://upload.wikimedia.org/wikipedia/commons/6/62/CSS3_logo.svg" alt="CSS3 logo" height="50">](https://www.w3.org/TR/CSS/)
+
+***Link:*** [GITHUB](https://github.com/robert-godlewski/ghost_pants_website)
+
+**Started Date:** July 2024
+
+***Description:*** Blog Website talking about video games.
+* Serialized [Django](https://www.djangoproject.com/) for fast access between the API and the frontend framework.
+* Implemented [React.js](https://react.dev/) to gather data from different API calls for the UI.
+* Utilized JWT for user authentification for user privacy on the site.
+----Need to implement below----
+* Deployed both the backend and frontend of the site using Choreo.

--- a/src/markdown/coding_portfolio/gp_website.md
+++ b/src/markdown/coding_portfolio/gp_website.md
@@ -7,11 +7,9 @@
 
 ***Link:*** [GITHUB](https://github.com/robert-godlewski/ghost_pants_website)
 
-**Started Date:** July 2024
+**Started Date:** June 2024
 
 ***Description:*** Blog Website talking about video games.
-* Serialized [Django](https://www.djangoproject.com/) for fast access between the API and the frontend framework.
-* Implemented [React.js](https://react.dev/) to gather data from different API calls for the UI.
-* Utilized JWT for user authentification for user privacy on the site.
-----Need to implement below----
-* Deployed both the backend and frontend of the site using Choreo.
+* Serialized [Django](https://www.djangoproject.com/) ORM as an API inorder for [React.js](https://react.dev/) to render 5 routes to be viewed for the UI.
+* Utilized JWT to authorize users for fast access to sensitive data.
+* Deployed full stack application using Choreo for people to engage with the live site.

--- a/src/markdown/coding_portfolio/job_search_bot.md
+++ b/src/markdown/coding_portfolio/job_search_bot.md
@@ -1,0 +1,13 @@
+## Job Search Bot
+***Role:*** Developer
+
+***Tech Stack:*** [Python](https://www.python.org/) and Selenium
+
+[<img src="https://upload.wikimedia.org/wikipedia/commons/c/c3/Python-logo-notext.svg" alt="Python logo" height="50">](https://www.python.org/)
+
+***Links:***
+
+**Started Date:** July 2024?
+
+***Description:*** Utilizing a web driver to automatically apply to jobs online.
+----Need to implement below----


### PR DESCRIPTION
Generally more Python based projects that reflect more of what I want to specialize in as a  backend Python developer with a specialty of Django-React development.

Projects so far in 2024 to add in:
* GhostPants website:  It's where I blog about video games.  This is where I really start to show my expertise with Django-React development.  Also will be the beginning of hosting the some video game in the future that I have developed.
* Earth Temperature Analytics:  This is just mainly a graph representing the effects of global warming via working with numpy, pandas, and matplotlib.
* Job Search Bot:  This will help me actually apply to jobs on a massive scale as well as show some expertise with automation via python and Selenium.